### PR TITLE
Enable Travis CI IPv6 loopback network for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
 script:
   - make CC="$CC --coverage"
   - file ./newlisp && ./newlisp -v
-  - make testall
+  - make checkall
 
 after_success:
   - coveralls --exclude util

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c
 
-sudo: false
+sudo: required
+
+services:
+  - docker
 
 os:
   - linux
@@ -39,6 +42,7 @@ matrix:
       after_success: echo "Skip report coverage"
 
 before_install:
+  - source ./ci/before_install_${TRAVIS_OS_NAME}.sh
   - source ./ci/coveralls/before_install_${TRAVIS_OS_NAME}.sh
   - pip install --user codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: c
 dist: trusty
 sudo: required
 
-services:
-  - docker
-
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 
+dist: trusty
 sudo: required
 
 services:

--- a/ci/before_install_linux.sh
+++ b/ci/before_install_linux.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+sudo /sbin/sysctl -a | grep -F ipv6.conf | grep disable
+sudo /sbin/sysctl -w net.ipv6.conf.all.disable_ipv6=0
+sudo /sbin/sysctl -w net.ipv6.conf.default.disable_ipv6=0
+sudo /sbin/sysctl -w net.ipv6.conf.lo.disable_ipv6=0
+ip addr
 # Note: IPv6 is not available by default. workaround this:
 # https://github.com/travis-ci/travis-ci/issues/8891#issuecomment-353403729
 echo '{"ipv6":true, "fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json

--- a/ci/before_install_linux.sh
+++ b/ci/before_install_linux.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
-sudo /sbin/sysctl -a | grep -F ipv6.conf | grep disable
-sudo /sbin/sysctl -w net.ipv6.conf.all.disable_ipv6=0
-sudo /sbin/sysctl -w net.ipv6.conf.default.disable_ipv6=0
+## Enable ipv6 loopback only for testing
+# sudo /sbin/sysctl -w net.ipv6.conf.all.disable_ipv6=0
+# sudo /sbin/sysctl -w net.ipv6.conf.default.disable_ipv6=0
 sudo /sbin/sysctl -w net.ipv6.conf.lo.disable_ipv6=0
-ip addr
-# Note: IPv6 is not available by default. workaround this:
-# https://github.com/travis-ci/travis-ci/issues/8891#issuecomment-353403729
-echo '{"ipv6":true, "fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-sudo service docker restart
 ip addr

--- a/ci/before_install_linux.sh
+++ b/ci/before_install_linux.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Note: IPv6 is not available by default. workaround this:
+# https://github.com/travis-ci/travis-ci/issues/8891#issuecomment-353403729
+echo '{"ipv6":true, "fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+sudo service docker restart
+ip addr

--- a/ci/before_install_osx.sh
+++ b/ci/before_install_osx.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+# NOOP


### PR DESCRIPTION
Travis CI Build Environment is disable IPv6 by default.
Therefore, enable IPv6 network for testing newLISP IPv6 primitives (loopback only).

https://docs.travis-ci.com/user/reference/overview/
https://docs.travis-ci.com/user/build-environment-updates/2016-08-24/#added
> Explicitly disabling IPv6 as it is not supported on Google Compute Engine (related to travis-ci/packer-templates#216)
