### PR TITLE
test opengl examples on linux

### DIFF
--- a/examples/opengl-demo-ffi-lsp.txt
+++ b/examples/opengl-demo-ffi-lsp.txt
@@ -2,9 +2,10 @@
 # OpenGL and GLUT demo - opengl-demo-ffi.lsp
 # Using extended import and callback API based on libffi
 # tested on Win32 and OS X 32/64-bit (Intel) minimum version newLISP 10.3.10
+# tested on Linux 32/64-bit (AMD) minimum version newLISP 10.7.0
 
-# verson 2.1 December 2011 - remade with extended FFI for 32 and 64-bit
-# verson 2.2 February 2012 - check if newLISP compiled for extended FFI
+# version 2.1 December 2011 - remade with extended FFI for 32 and 64-bit
+# version 2.2 February 2012 - check if newLISP compiled for extended FFI
 # this version works on both, 32-bit and 64-bit newLISP
 # on a Mac OSX standard install everything neede for 32-bit or 64-bit
 # is included. On Windows XP and Windows 7, glut32.dll must be added. 
@@ -52,7 +53,7 @@
   (begin
     (set 'GL_LIB "opengl32.dll") ; works dfor both 32 and 64 bit
     (set 'GLUT_LIB (if is-64-bit "glut64.dll" "glut32.dll")))
-  (= ostype "Linux") ;; not tested
+  (= ostype "Linux")
   (begin
     (set 'GL_LIB "libGL.so")
     (set 'GLUT_LIB "libglut.so"))

--- a/examples/opengl-demo-ffi.lsp
+++ b/examples/opengl-demo-ffi.lsp
@@ -2,10 +2,11 @@
 # OpenGL and GLUT demo - opengl-demo-ffi.lsp
 # Using extended import and callback API based on libffi
 # tested on Windows and OS X 32/64-bit (Intel) minimum version newLISP 10.3.10
+# tested on Linux 32/64-bit (AMD) minimum version newLISP 10.7.0
 
-# verson 2.1 December 2011 - remade with extended FFI for 32 and 64-bit
-# verson 2.2 February 2012 - check if newLISP compiled for extended FFI
-# verson 2.3 April 2015 - changed ostype to Windows from Win32
+# version 2.1 December 2011 - remade with extended FFI for 32 and 64-bit
+# version 2.2 February 2012 - check if newLISP compiled for extended FFI
+# version 2.3 April 2015 - changed ostype to Windows from Win32
 # this version works on both, 32-bit and 64-bit newLISP
 # on a Mac OSX standard install everything neede for 32-bit or 64-bit
 # is included. On Windows XP and Windows 7, glut32.dll must be added. 
@@ -54,7 +55,7 @@
   (begin
     (set 'GL_LIB "opengl32.dll") ; works dfor both 32 and 64 bit
     (set 'GLUT_LIB (if is-64-bit "glut64.dll" "glut32.dll")))
-  (= ostype "Linux") ;; not tested
+  (= ostype "Linux")
   (begin
     (set 'GL_LIB "libGL.so")
     (set 'GLUT_LIB "libglut.so"))

--- a/examples/opengl-demo.lsp
+++ b/examples/opengl-demo.lsp
@@ -2,6 +2,7 @@
 # OpenGL and GLUT demo - opengl-demo.lsp
 # using simple import and callback API
 # tested on Windows and OS X (Intel) 32-bit only!
+# tested on Linux 32-bit (AMD) minimum version newLISP 10.7.5
 
 # version 1.2, July 2009 - make drawObject working with motion
 
@@ -16,7 +17,7 @@
 # glut32.dll -  available here: http://www.opengl.org/resources/libraries/glut/
 # Note! on Windows 7 glut32.dll should be installed c:/Windows/SysWOW64/ not system32
 # 
-# Linux/UNIX - not tested
+# Linux/UNIX
 # libGLU.so - should be on your Linux/UNIX installation or at www.opengl.org
 # glut-3.7.so - already on your system or at:
 #     http://www.opengl.org/resources/libraries/glut/
@@ -63,7 +64,7 @@
   (begin
     (set 'GL_LIB "opengl32.dll")
     (set 'GLUT_LIB "glut32.dll"))
-  (= ostype "Linux") ;; not tested
+  (= ostype "Linux")
   (begin
     (set 'GL_LIB "libGL.so")
     (set 'GLUT_LIB "libglut.so"))


### PR DESCRIPTION
## Tested files:
1. examples/opengl-demo-ffi-lsp.txt (on Linux 32/64-bit (AMD) minimum version newLISP 10.7.0)
2. examples/opengl-demo-ffi.lsp (on Linux 32/64-bit (AMD) minimum version newLISP 10.7.0)
3. examples/opengl-demo.lsp (on Linux 32-bit (AMD) minimum version newLISP 10.7.5)

Fixed some typos.